### PR TITLE
Create AsyncResult with Celery app

### DIFF
--- a/src/django_celery_boost/admin.py
+++ b/src/django_celery_boost/admin.py
@@ -109,8 +109,8 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
             self,
             request,
             doit,
-            "Do you really want to queue this task?",
-            "Queued",
+            message="Do you really want to queue this task?",
+            success_message="Queued",
             extra_context=ctx,
             description="",
             template=self.queue_template
@@ -146,8 +146,8 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
             self,
             request,
             doit,
-            "Do you really want to queue this task?",
-            "Revoked",
+            message="Do you really want to queue this task?",
+            success_message="Revoked",
             extra_context=ctx,
             description="",
             template=[
@@ -182,8 +182,8 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
             self,
             request,
             doit,
-            "Do you really want to terminate this task?",
-            None,
+            message="Do you really want to terminate this task?",
+            success_message=None,
             extra_context=ctx,
             description="",
             template=self.terminate_template

--- a/src/django_celery_boost/models.py
+++ b/src/django_celery_boost/models.py
@@ -223,7 +223,7 @@ class CeleryTaskModel(models.Model):
     def async_result(self) -> "AsyncResult|None":
         """Return the AsyncResult object of the current instance."""
         if self.curr_async_result_id:
-            return AsyncResult(self.curr_async_result_id)
+            return self.celery_app.AsyncResult(self.curr_async_result_id)
         return None
 
     @property


### PR DESCRIPTION
We get an error coming from `django-celery-boost`

AttributeError
'DisabledBackend' object has no attribute '_get_task_meta_for'

this error comes from the line in `django-celery-boost/src/django_celery_boost/models.py`
```
info = self.async_result._get_task_meta()
```

As proposed here https://stackoverflow.com/a/37408190 this can be solved by creating AsyncResult directly from Celery app instance or explicitly providing it in AsyncResult constructor call