### PR TITLE
Feature/graceful cancelation and progress tracking

### DIFF
--- a/src/django_celery_boost/admin.py
+++ b/src/django_celery_boost/admin.py
@@ -242,13 +242,13 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
         )
 
     def progress_info(self, obj: CeleryTaskModel) -> str:
-        """Display tracking message for use in list_display.
+        """Display progress info for use in list_display.
 
         Args:
             obj: The CeleryTaskModel instance
 
         Returns:
-            The tracking message or "-" if not available
+            Progress as 'current/total' or 'Unknown' if not available.
         """
         return obj.progress or "-"
 

--- a/src/django_celery_boost/admin.py
+++ b/src/django_celery_boost/admin.py
@@ -84,6 +84,13 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
     def celery_terminate(self, request: "HttpRequest", pk: str) -> "HttpResponse":  # type: ignore
         return self._celery_terminate(request, pk)
 
+    @button(
+        label="Graceful Cancel",
+        permission=lambda r, o, handler: handler.model_admin.has_queue_permission("terminate", r, o),
+    )
+    def celery_graceful_cancel(self, request: "HttpRequest", pk: str) -> "HttpResponse":  # type: ignore
+        return self._celery_graceful_cancel(request, pk)
+
     def _celery_queue(self, request: "HttpRequest", pk: str) -> "HttpResponse":  # type: ignore
         obj: CeleryTaskModel | None
         obj = self.get_object(request, pk)
@@ -195,3 +202,56 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
                 "%s/celery_boost/terminate.html" % self.admin_site.name,
             ],
         )
+
+    def _celery_graceful_cancel(self, request: "HttpRequest", pk: str) -> "HttpResponse":  # type: ignore
+        obj: CeleryTaskModel = self.get_object(request, pk)
+
+        if obj.task_status != CeleryTaskModel.STARTED:
+            self.message_user(
+                request, "Graceful cancel is only available for running (STARTED) tasks.", messages.WARNING
+            )
+            return None
+
+        ctx = self.get_common_context(request, pk, title=f"Confirm graceful cancel request for {obj}")
+
+        def doit(request: "HttpRequest") -> HttpResponseRedirect:
+            result = obj.request_graceful_termination()
+            redirect_url = reverse(
+                "%s:%s_%s_change" % (self.admin_site.name, obj._meta.app_label, obj._meta.model_name),
+                args=(obj.pk,),
+                current_app=self.admin_site.name,
+            )
+            if result:
+                self.message_user(request, "Graceful termination requested.", messages.SUCCESS)
+            else:
+                self.message_user(request, "Could not request graceful termination.", messages.ERROR)
+            return HttpResponseRedirect(redirect_url)
+
+        return confirm_action(
+            self,
+            request,
+            doit,
+            message="Do you really want to request graceful cancellation of this task?",
+            success_message=None,
+            extra_context=ctx,
+            description="The task will be notified to stop at the next checkpoint.",
+            template=self.terminate_template
+            or [
+                "%s/%s/%s/terminate.html" % (self.admin_site.name, self.opts.app_label, self.opts.model_name),
+                "%s/%s/terminate.html" % (self.admin_site.name, self.opts.app_label),
+                "%s/celery_boost/terminate.html" % self.admin_site.name,
+            ],
+        )
+
+    def tracking_display(self, obj: CeleryTaskModel) -> str:
+        """Display tracking message for use in list_display.
+
+        Args:
+            obj: The CeleryTaskModel instance
+
+        Returns:
+            The tracking message or "-" if not available
+        """
+        return obj.tracking_message or "-"
+
+    tracking_display.short_description = "Tracking"

--- a/src/django_celery_boost/admin.py
+++ b/src/django_celery_boost/admin.py
@@ -85,11 +85,11 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
         return self._celery_terminate(request, pk)
 
     @button(
-        label="Graceful Cancel",
+        label="Cancel",
         permission=lambda r, o, handler: handler.model_admin.has_queue_permission("terminate", r, o),
     )
-    def celery_graceful_cancel(self, request: "HttpRequest", pk: str) -> "HttpResponse":  # type: ignore
-        return self._celery_graceful_cancel(request, pk)
+    def celery_cancel(self, request: "HttpRequest", pk: str) -> "HttpResponse":  # type: ignore
+        return self._celery_cancel(request, pk)
 
     def _celery_queue(self, request: "HttpRequest", pk: str) -> "HttpResponse":  # type: ignore
         obj: CeleryTaskModel | None
@@ -203,19 +203,17 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
             ],
         )
 
-    def _celery_graceful_cancel(self, request: "HttpRequest", pk: str) -> "HttpResponse":  # type: ignore
+    def _celery_cancel(self, request: "HttpRequest", pk: str) -> "HttpResponse":  # type: ignore
         obj: CeleryTaskModel = self.get_object(request, pk)
 
         if obj.task_status != CeleryTaskModel.STARTED:
-            self.message_user(
-                request, "Graceful cancel is only available for running (STARTED) tasks.", messages.WARNING
-            )
+            self.message_user(request, "Cancel is only available for running (STARTED) tasks.", messages.WARNING)
             return None
 
-        ctx = self.get_common_context(request, pk, title=f"Confirm graceful cancel request for {obj}")
+        ctx = self.get_common_context(request, pk, title=f"Confirm cancel request for {obj}")
 
         def doit(request: "HttpRequest") -> HttpResponseRedirect:
-            result = obj.request_graceful_termination()
+            result = obj.request_cancellation()
             redirect_url = reverse(
                 "%s:%s_%s_change" % (self.admin_site.name, obj._meta.app_label, obj._meta.model_name),
                 args=(obj.pk,),
@@ -243,7 +241,7 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
             ],
         )
 
-    def tracking_display(self, obj: CeleryTaskModel) -> str:
+    def progress_info(self, obj: CeleryTaskModel) -> str:
         """Display tracking message for use in list_display.
 
         Args:
@@ -252,6 +250,6 @@ class CeleryTaskModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
         Returns:
             The tracking message or "-" if not available
         """
-        return obj.tracking_message or "-"
+        return obj.progress or "-"
 
-    tracking_display.short_description = "Tracking"
+    progress_info.short_description = "Progress"

--- a/src/django_celery_boost/models.py
+++ b/src/django_celery_boost/models.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import json
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Generator
 
 import sentry_sdk
@@ -19,7 +18,7 @@ from django.utils.functional import classproperty
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext as _
 
-from django_celery_boost.signals import task_queued, task_revoked, task_terminated
+from django_celery_boost.signals import task_queued, task_revoked, task_terminated, task_canceled
 from django_celery_boost.task import TaskRunFromSignature
 
 if TYPE_CHECKING:
@@ -371,7 +370,7 @@ class CeleryTaskModel(models.Model):
 
     def revoke(self, wait=False, timeout=None) -> None:
         if self.async_result:
-            self.async_result.revoke(terminate=False, signal="SIGTERM", wait=wait, timeout=timeout)
+            self.async_result.revoke(wait=wait, timeout=timeout)
         task_revoked.send(sender=self.__class__, task=self)
 
     def terminate(self, wait=False, timeout=None) -> str:
@@ -411,7 +410,7 @@ class CeleryTaskModel(models.Model):
         """Return the Redis key for tracking data."""
         return f"{CELERY_BOOST_TRACKING_KEY_PREFIX}:{self.curr_async_result_id}"
 
-    def set_tracking(self, message: str) -> None:
+    def set_tracking_info(self, field: str, value: str) -> None:
         """Update tracking data in Redis hash.
 
         Args:
@@ -423,10 +422,16 @@ class CeleryTaskModel(models.Model):
         with self.celery_app.pool.acquire(block=True) as conn:
             client = conn.default_channel.client
             key = self._get_tracking_key()
-            client.hset(key, "message", message)
+            client.hset(key, field, value)
             client.expire(key, CELERY_BOOST_TRACKING_TTL)
 
-    def get_tracking(self, *keys: str) -> dict | None:
+    def set_total(self, value: str | int) -> None:
+        self.set_tracking_info("total", str(value))
+
+    def set_progress(self, value: str | int) -> None:
+        self.set_tracking_info("progress", str(value))
+
+    def get_tracking_info(self, *fields: str) -> dict | None:
         """Read tracking data from Redis hash.
 
         Args:
@@ -442,12 +447,12 @@ class CeleryTaskModel(models.Model):
             client = conn.default_channel.client
             key = self._get_tracking_key()
 
-            if keys:
+            if fields:
                 # Get specific fields using HMGET
-                values = client.hmget(key, *keys)
+                values = client.hmget(key, *fields)
                 if not any(values):
                     return None
-                data = dict(zip(keys, values))
+                data = dict(zip(fields, values))
             else:
                 # Get all fields using HGETALL
                 data = client.hgetall(key)
@@ -462,17 +467,21 @@ class CeleryTaskModel(models.Model):
             }
 
     @property
-    def tracking(self) -> dict | None:
+    def tracking_info(self) -> dict | None:
         """Get tracking dict."""
-        return self.get_tracking()
+        return self.get_tracking_info()
 
     @property
-    def tracking_message(self) -> str:
-        """Get tracking message for display."""
-        data = self.get_tracking("message")
-        return data.get("message", "") if data else ""
+    def progress(self) -> str:
+        """Get progress message for display."""
+        data = self.get_tracking_info("total", "progress")
+        if data:
+            progress = data.get("progress", "Unknown")
+            total = data.get("total", "Unknown")
+            return f"{progress}/{total}"
+        return "Unknown"
 
-    def clear_tracking(self) -> None:
+    def clear_tracking_info(self) -> None:
         """Remove tracking data from Redis."""
         if not self.curr_async_result_id:
             return
@@ -482,7 +491,7 @@ class CeleryTaskModel(models.Model):
             key = self._get_tracking_key()
             client.delete(key)
 
-    def request_graceful_termination(self) -> bool:
+    def request_cancellation(self) -> bool:
         """Set terminate_requested flag in Redis.
 
         Returns:
@@ -491,25 +500,17 @@ class CeleryTaskModel(models.Model):
         if not self.curr_async_result_id:
             return False
 
-        mapping = {
-            "terminate_requested": "1",
-            "terminate_requested_at": datetime.utcnow().isoformat(),
-        }
-
-        with self.celery_app.pool.acquire(block=True) as conn:
-            client = conn.default_channel.client
-            key = self._get_tracking_key()
-            client.hset(key, mapping=mapping)
-            client.expire(key, CELERY_BOOST_TRACKING_TTL)
+        self.set_tracking_info("terminate_requested", "1")
         return True
 
+    @property
     def is_termination_requested(self) -> bool:
         """Check if termination was requested.
 
         Returns:
             True if termination was requested, False otherwise
         """
-        data = self.get_tracking("terminate_requested")
+        data = self.get_tracking_info("terminate_requested")
         if data:
             return data.get("terminate_requested") == "1"
         return False
@@ -551,6 +552,13 @@ class CeleryTaskModel(models.Model):
             return None
 
         return cls.objects.filter(curr_async_result_id=current_task.request.id).first()
+
+    def cancel(self) -> None:
+        if self.task_status == self.STARTED:
+            self.local_status = self.CANCELED
+            self.save(update_fields=["local_status"])
+            self.clear_tracking_info()
+            task_canceled.send(sender=self.__class__, task=self)
 
 
 class AsyncJobModel(CeleryTaskModel):

--- a/src/django_celery_boost/models.py
+++ b/src/django_celery_boost/models.py
@@ -542,6 +542,16 @@ class CeleryTaskModel(models.Model):
             conn.default_channel.client.delete(cls.celery_task_queue)
             conn.default_channel.client.delete(cls.celery_task_revoked_queue)
 
+    @classmethod
+    def get_current(cls) -> "CeleryTaskModel | None":
+        """Get the currently executing job by querying with Celery's task_id."""
+        from celery import current_task
+
+        if not current_task or not current_task.request.id:
+            return None
+
+        return cls.objects.filter(curr_async_result_id=current_task.request.id).first()
+
 
 class AsyncJobModel(CeleryTaskModel):
     class JobType(models.TextChoices):

--- a/src/django_celery_boost/models.py
+++ b/src/django_celery_boost/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Generator
 
 import sentry_sdk
@@ -28,6 +29,9 @@ if TYPE_CHECKING:
     from kombu.transport.redis import Channel
 
 logger = logging.getLogger(__name__)
+
+CELERY_BOOST_TRACKING_TTL = getattr(settings, "CELERY_BOOST_TRACKING_TTL", 86400 * 2)
+CELERY_BOOST_TRACKING_KEY_PREFIX = getattr(settings, "CELERY_BOOST_TRACKING_KEY_PREFIX", "celery:task:tracking")
 
 
 APP_LABEL = "app_label"
@@ -402,6 +406,113 @@ class CeleryTaskModel(models.Model):
         self.save(update_fields=["local_status", "curr_async_result_id"])
         task_terminated.send(sender=self.__class__, task=self)
         return st
+
+    def _get_tracking_key(self) -> str:
+        """Return the Redis key for tracking data."""
+        return f"{CELERY_BOOST_TRACKING_KEY_PREFIX}:{self.curr_async_result_id}"
+
+    def set_tracking(self, message: str) -> None:
+        """Update tracking data in Redis hash.
+
+        Args:
+            message: Task-defined status text (e.g., "45% - Processing 450/1000")
+        """
+        if not self.curr_async_result_id:
+            return
+
+        with self.celery_app.pool.acquire(block=True) as conn:
+            client = conn.default_channel.client
+            key = self._get_tracking_key()
+            client.hset(key, "message", message)
+            client.expire(key, CELERY_BOOST_TRACKING_TTL)
+
+    def get_tracking(self, *keys: str) -> dict | None:
+        """Read tracking data from Redis hash.
+
+        Args:
+            *keys: Optional field names to retrieve. If none provided, returns all fields.
+
+        Returns:
+            Dictionary with tracking data or None if not found
+        """
+        if not self.curr_async_result_id:
+            return None
+
+        with self.celery_app.pool.acquire(block=True) as conn:
+            client = conn.default_channel.client
+            key = self._get_tracking_key()
+
+            if keys:
+                # Get specific fields using HMGET
+                values = client.hmget(key, *keys)
+                if not any(values):
+                    return None
+                data = dict(zip(keys, values))
+            else:
+                # Get all fields using HGETALL
+                data = client.hgetall(key)
+                if not data:
+                    return None
+
+            # Decode bytes to strings if needed (Redis returns bytes)
+            return {
+                (k.decode() if isinstance(k, bytes) else k): (v.decode() if isinstance(v, bytes) else v)
+                for k, v in data.items()
+                if v is not None
+            }
+
+    @property
+    def tracking(self) -> dict | None:
+        """Get tracking dict."""
+        return self.get_tracking()
+
+    @property
+    def tracking_message(self) -> str:
+        """Get tracking message for display."""
+        data = self.get_tracking("message")
+        return data.get("message", "") if data else ""
+
+    def clear_tracking(self) -> None:
+        """Remove tracking data from Redis."""
+        if not self.curr_async_result_id:
+            return
+
+        with self.celery_app.pool.acquire(block=True) as conn:
+            client = conn.default_channel.client
+            key = self._get_tracking_key()
+            client.delete(key)
+
+    def request_graceful_termination(self) -> bool:
+        """Set terminate_requested flag in Redis.
+
+        Returns:
+            True if the flag was set, False if no task is running
+        """
+        if not self.curr_async_result_id:
+            return False
+
+        mapping = {
+            "terminate_requested": "1",
+            "terminate_requested_at": datetime.utcnow().isoformat(),
+        }
+
+        with self.celery_app.pool.acquire(block=True) as conn:
+            client = conn.default_channel.client
+            key = self._get_tracking_key()
+            client.hset(key, mapping=mapping)
+            client.expire(key, CELERY_BOOST_TRACKING_TTL)
+        return True
+
+    def is_termination_requested(self) -> bool:
+        """Check if termination was requested.
+
+        Returns:
+            True if termination was requested, False otherwise
+        """
+        data = self.get_tracking("terminate_requested")
+        if data:
+            return data.get("terminate_requested") == "1"
+        return False
 
     def signature(self) -> Signature:
         if not isinstance(self.task_handler, TaskRunFromSignature):

--- a/src/django_celery_boost/models.py
+++ b/src/django_celery_boost/models.py
@@ -411,10 +411,11 @@ class CeleryTaskModel(models.Model):
         return f"{CELERY_BOOST_TRACKING_KEY_PREFIX}:{self.curr_async_result_id}"
 
     def set_tracking_info(self, field: str, value: str) -> None:
-        """Update tracking data in Redis hash.
+        """Set a field in the tracking Redis hash.
 
         Args:
-            message: Task-defined status text (e.g., "45% - Processing 450/1000")
+            field: The field name to set
+            value: The value to store
         """
         if not self.curr_async_result_id:
             return
@@ -426,19 +427,21 @@ class CeleryTaskModel(models.Model):
             client.expire(key, CELERY_BOOST_TRACKING_TTL)
 
     def set_total(self, value: str | int) -> None:
+        """Set the total count for progress tracking."""
         self.set_tracking_info("total", str(value))
 
     def set_progress(self, value: str | int) -> None:
+        """Set the current progress count for progress tracking."""
         self.set_tracking_info("progress", str(value))
 
     def get_tracking_info(self, *fields: str) -> dict | None:
         """Read tracking data from Redis hash.
 
         Args:
-            *keys: Optional field names to retrieve. If none provided, returns all fields.
+            *fields: Optional field names to retrieve. If none provided, returns all fields.
 
         Returns:
-            Dictionary with tracking data or None if not found
+            Dictionary with tracking data or None if not found.
         """
         if not self.curr_async_result_id:
             return None
@@ -473,7 +476,7 @@ class CeleryTaskModel(models.Model):
 
     @property
     def progress(self) -> str:
-        """Get progress message for display."""
+        """Get progress as 'current/total' string for display."""
         data = self.get_tracking_info("total", "progress")
         if data:
             progress = data.get("progress", "Unknown")
@@ -492,10 +495,13 @@ class CeleryTaskModel(models.Model):
             client.delete(key)
 
     def request_cancellation(self) -> bool:
-        """Set terminate_requested flag in Redis.
+        """Request cooperative cancellation of a running task.
+
+        Sets a flag in Redis that the task can check via `is_termination_requested`.
+        The task must cooperatively check this flag and stop execution.
 
         Returns:
-            True if the flag was set, False if no task is running
+            True if the flag was set, False if no task is running.
         """
         if not self.curr_async_result_id:
             return False
@@ -505,10 +511,10 @@ class CeleryTaskModel(models.Model):
 
     @property
     def is_termination_requested(self) -> bool:
-        """Check if termination was requested.
+        """Check if cancellation was requested via `request_cancellation()`.
 
         Returns:
-            True if termination was requested, False otherwise
+            True if cancellation was requested, False otherwise.
         """
         data = self.get_tracking_info("terminate_requested")
         if data:
@@ -554,6 +560,11 @@ class CeleryTaskModel(models.Model):
         return cls.objects.filter(curr_async_result_id=current_task.request.id).first()
 
     def cancel(self) -> None:
+        """Mark the task as cancelled and clean up tracking data.
+
+        Call this from within the task when stopping due to cancellation request.
+        Only works when task status is STARTED. Sends `task_canceled` signal.
+        """
         if self.task_status == self.STARTED:
             self.local_status = self.CANCELED
             self.save(update_fields=["local_status"])

--- a/src/django_celery_boost/signals.py
+++ b/src/django_celery_boost/signals.py
@@ -4,6 +4,7 @@ from django.dispatch import Signal
 task_queued = Signal()
 task_revoked = Signal()
 task_terminated = Signal()
+task_canceled = Signal()
 
 # events
 task_complete = Signal()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -108,3 +108,58 @@ def test_check_status(request, django_app, std_user, job, queued):
     url = reverse("admin:demo_job_check_status")
     res = django_app.get(url, user=std_user)
     assert res.status_code == 302
+
+
+def test_celery_graceful_cancel_permission(django_app, std_user, job):
+    """Test graceful cancel requires terminate permission."""
+    url = reverse("admin:demo_job_celery_graceful_cancel", args=[job.pk])
+    res = django_app.get(url, user=std_user, expect_errors=True)
+    assert res.status_code == 403
+
+
+def test_celery_graceful_cancel_not_started(django_app, std_user, job):
+    """Test graceful cancel only works for STARTED tasks."""
+    url = reverse("admin:demo_job_celery_graceful_cancel", args=[job.pk])
+
+    with user_grant_permission(std_user, ["demo.terminate_job", "demo.change_job"]):
+        res = django_app.get(url, user=std_user).follow()
+        msgs = res.context["messages"]
+        assert [m.message for m in msgs] == ["Graceful cancel is only available for running (STARTED) tasks."]
+
+        job.queue()
+        res = django_app.get(url, user=std_user).follow()
+        msgs = res.context["messages"]
+        assert [m.message for m in msgs] == ["Graceful cancel is only available for running (STARTED) tasks."]
+
+
+def test_celery_graceful_cancel_started(django_app, std_user, job):
+    """Test graceful cancel works for STARTED tasks."""
+    url = reverse("admin:demo_job_celery_graceful_cancel", args=[job.pk])
+    job.queue()
+
+    with user_grant_permission(std_user, ["demo.terminate_job", "demo.change_job"]):
+        with mock.patch.object(Job, "task_status", Job.STARTED):
+            res = django_app.get(url, user=std_user)
+            assert res.status_code == 200
+
+            res = res.forms[1].submit().follow()
+            msgs = res.context["messages"]
+            assert [m.message for m in msgs] == ["Graceful termination requested."]
+
+            job.refresh_from_db()
+            assert job.is_termination_requested() is True
+
+
+def test_tracking_display(db):
+    """Test tracking_display admin method."""
+    from demo.factories import JobFactory
+    from django_celery_boost.admin import CeleryTaskModelAdmin
+
+    admin = CeleryTaskModelAdmin(Job, None)
+    job = JobFactory()
+
+    assert admin.tracking_display(job) == "-"
+
+    job.queue()
+    job.set_tracking("75% complete")
+    assert admin.tracking_display(job) == "75% complete"

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -110,31 +110,31 @@ def test_check_status(request, django_app, std_user, job, queued):
     assert res.status_code == 302
 
 
-def test_celery_graceful_cancel_permission(django_app, std_user, job):
-    """Test graceful cancel requires terminate permission."""
-    url = reverse("admin:demo_job_celery_graceful_cancel", args=[job.pk])
+def test_celery_cancel_permission(django_app, std_user, job):
+    """Test cancel requires terminate permission."""
+    url = reverse("admin:demo_job_celery_cancel", args=[job.pk])
     res = django_app.get(url, user=std_user, expect_errors=True)
     assert res.status_code == 403
 
 
-def test_celery_graceful_cancel_not_started(django_app, std_user, job):
-    """Test graceful cancel only works for STARTED tasks."""
-    url = reverse("admin:demo_job_celery_graceful_cancel", args=[job.pk])
+def test_celery_cancel_not_started(django_app, std_user, job):
+    """Test cancel only works for STARTED tasks."""
+    url = reverse("admin:demo_job_celery_cancel", args=[job.pk])
 
     with user_grant_permission(std_user, ["demo.terminate_job", "demo.change_job"]):
         res = django_app.get(url, user=std_user).follow()
         msgs = res.context["messages"]
-        assert [m.message for m in msgs] == ["Graceful cancel is only available for running (STARTED) tasks."]
+        assert [m.message for m in msgs] == ["Cancel is only available for running (STARTED) tasks."]
 
         job.queue()
         res = django_app.get(url, user=std_user).follow()
         msgs = res.context["messages"]
-        assert [m.message for m in msgs] == ["Graceful cancel is only available for running (STARTED) tasks."]
+        assert [m.message for m in msgs] == ["Cancel is only available for running (STARTED) tasks."]
 
 
-def test_celery_graceful_cancel_started(django_app, std_user, job):
-    """Test graceful cancel works for STARTED tasks."""
-    url = reverse("admin:demo_job_celery_graceful_cancel", args=[job.pk])
+def test_celery_cancel_started(django_app, std_user, job):
+    """Test cancel works for STARTED tasks."""
+    url = reverse("admin:demo_job_celery_cancel", args=[job.pk])
     job.queue()
 
     with user_grant_permission(std_user, ["demo.terminate_job", "demo.change_job"]):
@@ -147,19 +147,34 @@ def test_celery_graceful_cancel_started(django_app, std_user, job):
             assert [m.message for m in msgs] == ["Graceful termination requested."]
 
             job.refresh_from_db()
-            assert job.is_termination_requested() is True
+            assert job.is_termination_requested is True
 
 
-def test_tracking_display(db):
-    """Test tracking_display admin method."""
+def test_celery_cancel_failure(django_app, std_user, job):
+    """Test cancel shows error when request_cancellation fails."""
+    url = reverse("admin:demo_job_celery_cancel", args=[job.pk])
+    job.queue()
+
+    with user_grant_permission(std_user, ["demo.terminate_job", "demo.change_job"]):
+        with mock.patch.object(Job, "task_status", Job.STARTED):
+            with mock.patch.object(Job, "request_cancellation", return_value=False):
+                res = django_app.get(url, user=std_user)
+                res = res.forms[1].submit().follow()
+                msgs = res.context["messages"]
+                assert [m.message for m in msgs] == ["Could not request graceful termination."]
+
+
+def test_progress_info(db):
+    """Test progress_info admin method."""
     from demo.factories import JobFactory
     from django_celery_boost.admin import CeleryTaskModelAdmin
 
     admin = CeleryTaskModelAdmin(Job, None)
     job = JobFactory()
 
-    assert admin.tracking_display(job) == "-"
+    assert admin.progress_info(job) == "Unknown"
 
     job.queue()
-    job.set_tracking("75% complete")
-    assert admin.tracking_display(job) == "75% complete"
+    job.set_total(100)
+    job.set_progress(75)
+    assert admin.progress_info(job) == "75/100"

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,3 +1,5 @@
+"""Tests for task tracking and graceful termination functionality."""
+
 from uuid import uuid4
 
 from demo.factories import JobFactory
@@ -7,56 +9,76 @@ from django_celery_boost.models import CELERY_BOOST_TRACKING_KEY_PREFIX
 
 
 def test_tracking_no_task_id(db):
+    """Tracking methods should handle missing curr_async_result_id gracefully."""
     job: Job = JobFactory()
 
-    job.set_tracking("test")
-    assert job.get_tracking() is None
-    assert job.tracking is None
-    assert job.tracking_message == ""
-    job.clear_tracking()
+    job.set_tracking_info("progress", "50")
+    assert job.get_tracking_info() is None
+    assert job.tracking_info is None
+    assert job.progress == "Unknown"
+    job.clear_tracking_info()
 
 
 def test_tracking_set_get(db):
+    """Test setting and getting tracking data."""
     job: Job = JobFactory()
     job.queue()
 
-    job.set_tracking("50% - Processing 500/1000")
-    tracking = job.get_tracking()
+    job.set_tracking_info("custom_field", "custom_value")
+    tracking = job.get_tracking_info()
 
     assert tracking is not None
-    assert tracking["message"] == "50% - Processing 500/1000"
+    assert tracking["custom_field"] == "custom_value"
 
 
-def test_tracking_property(db):
+def test_set_progress_and_total(db):
+    """Test set_progress and set_total helper methods."""
     job: Job = JobFactory()
     job.queue()
 
-    job.set_tracking("Test message")
-    assert job.tracking == job.get_tracking()
+    job.set_total(1000)
+    job.set_progress(500)
+
+    tracking = job.get_tracking_info()
+    assert tracking["total"] == "1000"
+    assert tracking["progress"] == "500"
 
 
-def test_tracking_message_property(db):
+def test_tracking_info_property(db):
+    """Test tracking_info property returns same as get_tracking_info."""
     job: Job = JobFactory()
     job.queue()
 
-    assert job.tracking_message == ""
+    job.set_tracking_info("test", "value")
+    assert job.tracking_info == job.get_tracking_info()
 
-    job.set_tracking("Processing...")
-    assert job.tracking_message == "Processing..."
+
+def test_progress_property(db):
+    """Test progress property."""
+    job: Job = JobFactory()
+    job.queue()
+
+    assert job.progress == "Unknown"
+
+    job.set_total(100)
+    job.set_progress(50)
+    assert job.progress == "50/100"
 
 
 def test_tracking_clear(db):
+    """Test clearing tracking data."""
     job: Job = JobFactory()
     job.queue()
 
-    job.set_tracking("Test")
-    assert job.get_tracking() is not None
+    job.set_tracking_info("test", "value")
+    assert job.get_tracking_info() is not None
 
-    job.clear_tracking()
-    assert job.get_tracking() is None
+    job.clear_tracking_info()
+    assert job.get_tracking_info() is None
 
 
 def test_tracking_key_format(db):
+    """Test the Redis key format is correct."""
     job: Job = JobFactory()
     task_id = str(uuid4())
     job.curr_async_result_id = task_id
@@ -66,35 +88,90 @@ def test_tracking_key_format(db):
     assert job._get_tracking_key() == expected_key
 
 
-def test_request_termination_no_task_id(db):
+def test_request_cancellation_no_task_id(db):
+    """Request cancellation should return False without task ID."""
     job: Job = JobFactory()
 
-    assert job.request_graceful_termination() is False
-    assert job.is_termination_requested() is False
+    assert job.request_cancellation() is False
+    assert job.is_termination_requested is False
 
 
-def test_request_termination(db):
+def test_request_cancellation(db):
+    """Test requesting cancellation."""
     job: Job = JobFactory()
     job.queue()
 
-    assert job.is_termination_requested() is False
+    assert job.is_termination_requested is False
 
-    result = job.request_graceful_termination()
+    result = job.request_cancellation()
     assert result is True
-    assert job.is_termination_requested() is True
+    assert job.is_termination_requested is True
 
-    tracking = job.get_tracking()
+    tracking = job.get_tracking_info()
     assert tracking["terminate_requested"] == "1"
-    assert "terminate_requested_at" in tracking
 
 
 def test_termination_flag_persists_with_tracking(db):
+    """Termination flag should persist alongside tracking updates."""
     job: Job = JobFactory()
     job.queue()
 
-    job.request_graceful_termination()
-    assert job.is_termination_requested() is True
+    job.request_cancellation()
+    assert job.is_termination_requested is True
 
-    job.set_tracking("Still processing...")
-    assert job.is_termination_requested() is True
-    assert job.tracking_message == "Still processing..."
+    job.set_progress(100)
+    assert job.is_termination_requested is True
+
+
+def test_cancel(db):
+    """Test cancel method sets status and clears tracking."""
+    from unittest.mock import patch, PropertyMock
+
+    job: Job = JobFactory()
+    job.queue()
+
+    job.set_total(100)
+    job.set_progress(50)
+    assert job.get_tracking_info() is not None
+
+    with patch.object(Job, "task_status", new_callable=PropertyMock) as mock_status:
+        mock_status.return_value = Job.STARTED
+        job.cancel()
+
+    job.refresh_from_db()
+    assert job.local_status == Job.CANCELED
+    assert job.get_tracking_info() is None
+
+
+def test_cancel_only_for_started(db):
+    """Test cancel only works for STARTED tasks."""
+    job: Job = JobFactory()
+    job.queue()
+
+    job.set_progress(50)
+    job.cancel()
+
+    job.refresh_from_db()
+    assert job.local_status != Job.CANCELED
+    assert job.get_tracking_info() is not None
+
+
+def test_get_current_outside_task(db):
+    """Test get_current returns None when not in a Celery task."""
+    result = Job.get_current()
+    assert result is None
+
+
+def test_get_current_with_mock(db):
+    """Test get_current returns the job when in a Celery task context."""
+    from unittest.mock import patch, MagicMock
+
+    job: Job = JobFactory()
+    job.queue()
+
+    mock_task = MagicMock()
+    mock_task.request.id = job.curr_async_result_id
+
+    with patch("celery.current_task", mock_task):
+        result = Job.get_current()
+        assert result == job

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,0 +1,100 @@
+from uuid import uuid4
+
+from demo.factories import JobFactory
+from demo.models import Job
+
+from django_celery_boost.models import CELERY_BOOST_TRACKING_KEY_PREFIX
+
+
+def test_tracking_no_task_id(db):
+    job: Job = JobFactory()
+
+    job.set_tracking("test")
+    assert job.get_tracking() is None
+    assert job.tracking is None
+    assert job.tracking_message == ""
+    job.clear_tracking()
+
+
+def test_tracking_set_get(db):
+    job: Job = JobFactory()
+    job.queue()
+
+    job.set_tracking("50% - Processing 500/1000")
+    tracking = job.get_tracking()
+
+    assert tracking is not None
+    assert tracking["message"] == "50% - Processing 500/1000"
+
+
+def test_tracking_property(db):
+    job: Job = JobFactory()
+    job.queue()
+
+    job.set_tracking("Test message")
+    assert job.tracking == job.get_tracking()
+
+
+def test_tracking_message_property(db):
+    job: Job = JobFactory()
+    job.queue()
+
+    assert job.tracking_message == ""
+
+    job.set_tracking("Processing...")
+    assert job.tracking_message == "Processing..."
+
+
+def test_tracking_clear(db):
+    job: Job = JobFactory()
+    job.queue()
+
+    job.set_tracking("Test")
+    assert job.get_tracking() is not None
+
+    job.clear_tracking()
+    assert job.get_tracking() is None
+
+
+def test_tracking_key_format(db):
+    job: Job = JobFactory()
+    task_id = str(uuid4())
+    job.curr_async_result_id = task_id
+    job.save()
+
+    expected_key = f"{CELERY_BOOST_TRACKING_KEY_PREFIX}:{task_id}"
+    assert job._get_tracking_key() == expected_key
+
+
+def test_request_termination_no_task_id(db):
+    job: Job = JobFactory()
+
+    assert job.request_graceful_termination() is False
+    assert job.is_termination_requested() is False
+
+
+def test_request_termination(db):
+    job: Job = JobFactory()
+    job.queue()
+
+    assert job.is_termination_requested() is False
+
+    result = job.request_graceful_termination()
+    assert result is True
+    assert job.is_termination_requested() is True
+
+    tracking = job.get_tracking()
+    assert tracking["terminate_requested"] == "1"
+    assert "terminate_requested_at" in tracking
+
+
+def test_termination_flag_persists_with_tracking(db):
+    job: Job = JobFactory()
+    job.queue()
+
+    job.request_graceful_termination()
+    assert job.is_termination_requested() is True
+
+    job.set_tracking("Still processing...")
+    assert job.is_termination_requested() is True
+    assert job.tracking_message == "Still processing..."


### PR DESCRIPTION
Add task tracking and cooperative cancellation

Tasks can report progress via set_total() and set_progress() methods, displayed in admin
Admin "Cancel" button requests graceful cancellation of running tasks
Tasks check is_termination_requested property and call cancel() to stop cleanly
New get_current() class method to retrieve the executing job instance from within a task
Tracking data stored in Redis hash with configurable TTL
New signal: task_canceled
Settings: CELERY_BOOST_TRACKING_TTL, CELERY_BOOST_TRACKING_KEY_PREFIX